### PR TITLE
Post autocomplete

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,10 @@ gem 'carrierwave', '~> 3.0'
 gem 'mini_magick'
 gem "aws-sdk-s3", require: false
 gem 'fog-aws'
+gem 'faker'
+
+# map
+gem "geocoder"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
+    csv (3.3.0)
     date (3.3.4)
     debug (1.9.2)
       irb (~> 1.10)
@@ -141,6 +142,8 @@ GEM
     drb (2.2.1)
     erubi (1.12.0)
     excon (0.110.0)
+    faker (3.4.1)
+      i18n (>= 1.8.11, < 2)
     ffi (1.17.0-aarch64-linux-gnu)
     ffi (1.17.0-arm-linux-gnu)
     ffi (1.17.0-arm64-darwin)
@@ -163,6 +166,9 @@ GEM
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (1.1.0)
+    geocoder (1.8.3)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.5)
@@ -359,7 +365,9 @@ DEPENDENCIES
   debug
   devise
   dotenv-rails
+  faker
   fog-aws
+  geocoder
   jbuilder
   jsbundling-rails
   letter_opener_web

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -52,6 +52,6 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:title, :address, :body, :images_cache, images: [])
+    params.require(:post).permit(:title, :address, :body, :images_cache, :latitude, :longitude, images: [])
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -10,14 +10,15 @@ class Post < ApplicationRecord
   validate :validate_address
 
   geocoded_by :address
-  after_validation :geocode
+  after_validation :geocode, if: :address_changed?
 
   mount_uploaders :images, ImageUploader
 
   # 北部九州のスポットかのチェック
   def check_address
-    unless self.address.match?(/\A(?:福岡県|佐賀県|長崎県|熊本県|大分県)/)
-      errors.add(:base, "住所は 福岡県|佐賀県|長崎県|熊本県|大分県 から始まるものを入力してください")
+    northern_kyushu_addresses = ["福岡県", "佐賀県", "長崎県", "熊本県", "大分県"]
+    unless northern_kyushu_addresses.any? { |addr| self.address.include?(addr) }
+      errors.add(:base, "北部九州の住所を入力してください")
     end
   end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,6 +7,10 @@ class Post < ApplicationRecord
   validates :images, length: { maximum: 3, message: '写真は3枚までしかアップロードできません' }
 
   validate :check_address
+  validate :validate_address
+
+  geocoded_by :address
+  after_validation :geocode
 
   mount_uploaders :images, ImageUploader
 
@@ -15,5 +19,13 @@ class Post < ApplicationRecord
     unless self.address.match?(/\A(?:福岡県|佐賀県|長崎県|熊本県|大分県)/)
       errors.add(:base, "住所は 福岡県|佐賀県|長崎県|熊本県|大分県 から始まるものを入力してください")
     end
+  end
+
+  # 住所が存在するかのチェック
+  def validate_address
+    geocoded = Geocoder.search(address)
+    return if geocoded&.first&.coordinates.present?
+
+    errors.add(:address, '住所が存在しません')
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   </head>
 
   <body class="flex flex-col h-screen">

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,3 +1,6 @@
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAPS_API_KEY"] %>&libraries=places&callback=initAutocomplete" async defer>
+</script>
+
 <div class="min-h-screen">
   <div class="flex justify-center my-14">
     <div class="card w-[800px]  bg-neutral-content text-neutral-600">
@@ -13,17 +16,17 @@
           <%= render 'shared/error_messages', object: f.object %>
           <div class="flex flex-col mt-5">
             <%= f.label :title, "タイトル" %>
-            <%= f.text_field :title, placeholder: "スポット名や市町村名", class: "input input-bordered w-full", autocomplete: "off" %>
+            <%= f.text_field :title, id: "Title", placeholder: "スポット名や市町村名", class: "input input-bordered w-full", autocomplete: "off" %>
             <span class="text-xs text-right mt-1">必須</span>
           </div>
           <div class="flex flex-col mt-5">
             <%= f.label :address, "住所" %>
-            <%= f.text_field :address, placeholder: "県名から住所入力", class: "input input-bordered w-full", autocomplete: "off" %>
+            <%= f.text_field :address, id: "Address", placeholder: "県名から住所入力", class: "input input-bordered w-full", autocomplete: "off" %>
             <span class="text-xs text-right mt-1">必須（同じ住所は投稿できません）</span>
           </div>
           <div class="flex flex-col mt-5">
             <%= f.label :body, "コメント" %>
-            <%= f.text_area :body, placeholder: "スポットの説明、おすすめポイント", class: "input input-bordered w-full textarea", autocomplete: "off" %>
+            <%= f.text_area :body, id: "Body", placeholder: "スポットの説明、おすすめポイント", class: "input input-bordered w-full textarea", autocomplete: "off" %>
             <span id="charCount" class="text-xs text-right mt-1">300文字まで</span>
           </div>
           <div class="flex flex-col mt-5">
@@ -49,3 +52,33 @@
     </div>
   </div>
 </div>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  let inputTitle = document.getElementById('Title');
+  let inputAddress = document.getElementById('Address');
+
+  // 日本の施設に設定
+  let options = {
+    types: ['establishment'],
+    componentRestrictions: { country: 'JP' },
+  };
+
+  // オートコンプリート適用
+  let autocompleteTitle = new google.maps.places.Autocomplete(inputTitle, options);
+  let autocompleteAddress = new google.maps.places.Autocomplete(inputAddress, options);
+
+  // タイトルのオートコンプリートが選択されたとき
+  autocompleteTitle.addListener('place_changed', function() {
+    let place = autocompleteTitle.getPlace();
+    inputTitle.value = place.name;
+    inputAddress.value = place.formatted_address;
+  });
+
+  // 住所のオートコンプリートが選択されたとき
+  autocompleteAddress.addListener('place_changed', function() {
+    let place = autocompleteAddress.getPlace();
+    inputTitle.value = place.name;
+    inputAddress.value = place.formatted_address;
+  });
+});
+</script>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,6 +1,6 @@
 <div class="min-h-screen">
   <div class="flex justify-center my-10">
-    <div class="card w-6/12 bg-base-100 shadow-xl text-neutral-600 border border-gray-300">
+    <div class="card w-5/12 bg-base-100 shadow-xl text-neutral-600 border border-gray-300">
       <div class="justify-left p-10">
         <div>
           <%= link_to posts_path do %>
@@ -63,14 +63,19 @@
         <% end %>
       </figure>
       <div class="card-body">
-        <div class="px-1 sm:px-28">
-          <div class="flex items-start justify-between">
+        <div class="px-5">
+          <div class="flex items-center">
             <p class="text-3xl font-bold"><%= @post.title %></p>
             <% if current_user.own_post?(@post) %>
-              <div class="flex justify-end">
-                <%= link_to "編集", edit_post_path(@post), class: "btn mr-2 text-xs text-neutral-600" %>
-                <%= button_to "削除", post_path(@post), data: { turbo_method: :delete, turbo_confirm: '削除しますか?' }, class: "btn text-xs text-neutral-600" %>
-              </div>
+
+                  <%= link_to(edit_post_path(@post), class: "tooltip", "data-tip" => "編集") do %>
+                    <i class="fa fa-pencil p-2 hover:text-accent" aria-hidden="true"></i>
+                  <% end %>
+
+                  <%= link_to(post_path(@post), data: { turbo_method: :delete, turbo_confirm: '削除しますか?' }, class: "tooltip", "data-tip" => "削除") do %>
+                    <i class="fa fa-trash p-2 hover:text-accent" aria-hidden="true"></i>
+                  <% end %>
+
             <% end %>
           </div>
           <div class="mt-9">

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,27 @@
+Geocoder.configure(
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  lookup: :google,         # name of geocoding service (symbol)
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  use_https: true,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  api_key: ENV['GOOGLE_MAPS_API_KEY'],               # API key for geocoding service
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+  # units: :mi,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+
+  # Cache configuration
+  # cache_options: {
+  #   expiration: 2.days,
+  #   prefix: 'geocoder:'
+  # }
+)

--- a/db/migrate/20240619143546_add_latitude_longitude_to_posts.rb
+++ b/db/migrate/20240619143546_add_latitude_longitude_to_posts.rb
@@ -1,0 +1,6 @@
+class AddLatitudeLongitudeToPosts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :posts, :latitude, :float, null: false
+    add_column :posts, :longitude, :float, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_17_075734) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_19_143546) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_17_075734) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.json "images"
+    t.float "latitude", null: false
+    t.float "longitude", null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 


### PR DESCRIPTION
投稿フォーマットのタイトル、住所にオートコンプリート導入
- postsテーブルにlatitude（緯度）、longitude（経度）を追加
- GoogleMapsAPI導入
  - GoogleGeocodingAPI、GemのGeocoderで住所から緯度経度取得
  - Google Places APIでオートコンプリート機能





















































































