### PR TITLE
fix:パスワードリセット

### DIFF
--- a/app/views/users/mailer/reset_password_instructions.html.erb
+++ b/app/views/users/mailer/reset_password_instructions.html.erb
@@ -3,7 +3,7 @@
 <p>Kyushu Travelをご利用いただきありがとうございます!</p>
 <p>パスワードを変更するためのリンクがリクエストされました。以下のリンクから変更できます。</p>
 
-<p><%= link_to 'パスワードを変更する', edit_user_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to 'パスワードを変更する', edit_password_url(@resource, reset_password_token: @token) %></p>
 
 <p>もしこのメールをリクエストしていないのであれば、無視してください。</p>
 <p>上記のリンクにアクセスして新しいパスワードを作成するまで、パスワードは変更されません。</p>


### PR DESCRIPTION
本番環境でのパスワードリセットリンクがlocalhostへ飛んでしまうため、メールリンクを変更。
